### PR TITLE
added qs middleware to fix upgrade issue for Connect v3.3.4

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ var bodyParser        = require('body-parser');
 var connectRoute      = require('connect-route');
 var http              = require('http');
 var ss                = require('socketstream');
-var qs                = require('qs');
+
 require('./server/internals');
 
 
@@ -44,7 +44,7 @@ var api = require(__dirname + '/server/api');
 
 
 ss.http.middleware.prepend(bodyParser.json());
-ss.http.middleware.prepend(qs);
+ss.http.middleware.prepend(require('./server/queryMiddleware')());
 ss.http.middleware.prepend(connectRoute(api));
 ss.session.options.secret = ss.api.app.config.sessionSecret;
 

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var bodyParser        = require('body-parser');
 var connectRoute      = require('connect-route');
 var http              = require('http');
 var ss                = require('socketstream');
+var qs                = require('qs');
 require('./server/internals');
 
 
@@ -43,7 +44,7 @@ var api = require(__dirname + '/server/api');
 
 
 ss.http.middleware.prepend(bodyParser.json());
-ss.http.middleware.prepend(ss.http.connect.query());
+ss.http.middleware.prepend(qs);
 ss.http.middleware.prepend(connectRoute(api));
 ss.session.options.secret = ss.api.app.config.sessionSecret;
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "engines"       : { "node": ">= 0.10.0" },
   "dependencies"  : {
+    "qs"            : "2.3.3",
     "bcrypt"        : "0.8.1",
     "body-parser"   : "1.11.0 ",
     "connect-route" : "0.1.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "engines"       : { "node": ">= 0.10.0" },
   "dependencies"  : {
+    "parseurl"      : "1.3.0",
     "qs"            : "2.3.3",
     "bcrypt"        : "0.8.1",
     "body-parser"   : "1.11.0 ",

--- a/server/queryMiddleware.js
+++ b/server/queryMiddleware.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Dependencies
+//
+var qs = require('qs');
+var parseurl = require('parseurl');
+
+// as in Connect v2.`x
+module.exports = function query(){
+  return function query(req, res, next){
+    if (!req.query) {
+      req.query = ~req.url.indexOf('?')
+        ? qs.parse(parseurl(req).query)
+        : {};
+    }
+
+    next();
+  };
+};


### PR DESCRIPTION
When upgrading SocketStream to use Connect v3.3.4, there will be some issues because the `query` middleware is no longer included.  

I've brought in the `qs` middleware to fix this.  Let me know if any problems.